### PR TITLE
[#71] Post Message 전용 API 추가 및 연동

### DIFF
--- a/src/constants/url.js
+++ b/src/constants/url.js
@@ -1,3 +1,6 @@
 const API_BASE_URL = 'https://rolling-api.vercel.app';
 
-export { API_BASE_URL };
+const MESSAGE_LIMIT_DEFAULT = 5;
+const MESSAGE_OFFSET_DEFAULT = 0;
+
+export { API_BASE_URL, MESSAGE_LIMIT_DEFAULT, MESSAGE_OFFSET_DEFAULT };

--- a/src/libs/api.js
+++ b/src/libs/api.js
@@ -1,5 +1,9 @@
 import axios from 'axios';
-import { API_BASE_URL } from 'constants/url';
+import {
+  API_BASE_URL,
+  MESSAGE_LIMIT_DEFAULT,
+  MESSAGE_OFFSET_DEFAULT,
+} from 'constants/url';
 
 const instance = axios.create({ baseURL: API_BASE_URL });
 
@@ -96,6 +100,21 @@ async function getRecipient(id) {
   const result = response.data;
   return result;
 }
+
+async function getMessage(
+  id,
+  limit = MESSAGE_LIMIT_DEFAULT,
+  offset = MESSAGE_OFFSET_DEFAULT
+) {
+  const query = `limit=${limit}&offset=${offset}`;
+  const response = await instance.get(
+    `/1-10/recipients/${id}/messages/?${query}`
+  );
+  const result = response.data;
+
+  return result;
+}
+
 export {
   getProfileImg,
   getRecipientMessage,
@@ -105,5 +124,5 @@ export {
   getBackgroundImg,
   createRecipient,
   getRecipient,
-
+  getMessage,
 };

--- a/src/pages/PostList.js
+++ b/src/pages/PostList.js
@@ -5,7 +5,7 @@ import EmptyCard from 'components/Card/EmptyCard';
 import Nav from 'components/Nav/Nav';
 import useColorToCode from 'hooks/useColorToCode';
 import useUserInfo from 'hooks/useUserInfo';
-import { getRecipient } from 'libs/api';
+import { getRecipient, getMessage } from 'libs/api';
 import styled from 'styled-components';
 //test id  = img  74    color 137
 function PostList() {
@@ -16,9 +16,7 @@ function PostList() {
   const [isImage, setIsImage] = useState(false);
 
   const init = (result) => {
-    const { recentMessages, backgroundImageURL, backgroundColor } = result;
-    setUserInfo(result);
-    setRecentMessages(recentMessages);
+    const { backgroundImageURL, backgroundColor } = result;
     if (backgroundImageURL) {
       setIsImage(true);
     } else {
@@ -30,6 +28,12 @@ function PostList() {
     await getRecipient(id).then((result) => {
       if (result) {
         init(result);
+        setUserInfo(result);
+      }
+    });
+    await getMessage(id).then((result) => {
+      if (result) {
+        setRecentMessages(result.results);
       }
     });
   };


### PR DESCRIPTION
## ✅ 작업 내용

- [x] 메세지 전용 API 추가 및 연동 로직 구현
- [x] limit ,offset 파라미터 추가 

## 📍 리뷰 포인트

- Message 전용 api 와 기존에 사용하던 로직 분리 하였습니다.
-

## 🗣️ 기타 사항

- API 명세서를 꼼꼼히 읽어보자..
-
<img width="1789" alt="image" src="https://github.com/10-rolling/rollingPolling/assets/72487120/389427ff-faac-4df9-9572-5a9c89d2127f">

